### PR TITLE
fix indendation in readme and include extra canopencomm info

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ only NMT messages are accepted.
 In *canopend terminal* you see, that both devices finished. Further commands
 are not possible. If you set so, last command can also reset computer.
 
+#### Combining NMT commands into a single file
+
+Create a `commands.txt` file, and for its content enter your commands.
+Example:
+
+    [1] 3 start
+    [2] 4 start
+
+Make canopencomm use that file:
+
+    $ ./canopencomm -f commands.txt
+    [1] OK
+    [2] OK
+
 
 ### Next steps
 Now you can learn more skills on CANopen from some other sources:

--- a/README.md
+++ b/README.md
@@ -237,47 +237,49 @@ The following example show some typical use cases for LSS:
 
  - Changing the node ID for a known slave, store the new node ID to eeprom, apply new node ID.
    The node currently has the node ID 22.
-    $ ./canopencomm lss_switch_sel 0x00000428 0x00000431 0x00000002 0x5C17EEBC 
-    $ ./canopencomm lss_set_node 4
-    $ ./canopencomm lss_store
-    $ ./canopencomm lss_switch_glob 0
-    $ ./canopencomm 22 reset communication
+
+        $ ./canopencomm lss_switch_sel 0x00000428 0x00000431 0x00000002 0x5C17EEBC 
+        $ ./canopencomm lss_set_node 4
+        $ ./canopencomm lss_store
+        $ ./canopencomm lss_switch_glob 0
+        $ ./canopencomm 22 reset communication
     
    Note that the node ID change is not done until reset communication/node
     
  - Changing the node ID for a known slave, store the new node ID to eeprom, apply new node ID.
    The node currently has an invalid node ID.
-    $ ./canopencomm lss_switch_sel 0x00000428 0x00000431 0x00000002 0x5C17EEBC 
-    $ ./canopencomm lss_set_node 4
-    $ ./canopencomm lss_store
-    $ ./canopencomm lss_switch_glob 0
+
+        $ ./canopencomm lss_switch_sel 0x00000428 0x00000431 0x00000002 0x5C17EEBC 
+        $ ./canopencomm lss_set_node 4
+        $ ./canopencomm lss_store
+        $ ./canopencomm lss_switch_glob 0
     
    Note that the node ID is automatically applied.
     
  - Search for a node via LSS fastscan, store the new node ID to eeprom, apply new node ID
  
-    $ ./canopencomm [1] _lss_fastscan
-    
-    [1] 0x00000428 0x00000432 0x00000002 0x6C81413C
-    
-    $ ./canopencomm lss_set_node 4
-    $ ./canopencomm lss_store
-    $ ./canopencomm lss_switch_glob 0
+        $ ./canopencomm [1] _lss_fastscan
+        
+        [1] 0x00000428 0x00000432 0x00000002 0x6C81413C
+        
+        $ ./canopencomm lss_set_node 4
+        $ ./canopencomm lss_store
+        $ ./canopencomm lss_switch_glob 0
  
-   To increase scanning speed, you can use 
-   
-    $ ./canopencomm [1] _lss_fastscan 25
-    
-   where 25 is the scan step delay in ms. Be aware that the scan will become unreliable when
-   the delay is set to low.
+    To increase scanning speed, you can use 
+
+        $ ./canopencomm [1] _lss_fastscan 25
+
+    where 25 is the scan step delay in ms. Be aware that the scan will become unreliable when
+    the delay is set to low.
    
  - Auto enumerate all nodes via LSS fastscan. Enumeration automatically begins at node ID 2
    and node ID is automatically stored to eeprom. Like with _lss_fastscan, an optional 
    parameter can be used to change default delay time.
  
-    $ ./canopencomm lss_allnodes
-    
-    [1] OK, found 3 nodes starting at node ID 2.
+        $ ./canopencomm lss_allnodes
+        
+        [1] OK, found 3 nodes starting at node ID 2.
 
  - To get further control over the fastscan process, the lss_allnodes command supports 
    an extended parameter set. If you want to use this set, all parameters are mandatory. 
@@ -285,9 +287,9 @@ The following example show some typical use cases for LSS:
    to node ID 7, do not store LSS address in eeprom, enumerate only devices with vendor ID
    "0x428", ignore product code and software revision, scan for serial number
     
-    $ ./canopencomm lss_allnodes 25 7 0 2 0x428 1 0 1 0 0 0
-    
-    [1] OK, found 2 nodes starting at node ID 7.
+        $ ./canopencomm lss_allnodes 25 7 0 2 0x428 1 0 1 0 0 0
+        
+        [1] OK, found 2 nodes starting at node ID 7.
     
    The parameters are as following:
    - 25     scan step delay time in ms


### PR DESCRIPTION
Had to go through the source code to find out how canopencomm works with input files, so I've added that info to the readme.