### PR TITLE
increase buffer size, use malloc for large buffers

### DIFF
--- a/canopencgi/CANopenCGI.c
+++ b/canopencgi/CANopenCGI.c
@@ -39,7 +39,7 @@
 
 
 #ifndef BUF_SIZE
-#define BUF_SIZE            100000
+#define BUF_SIZE            1000000
 #endif
 
 

--- a/canopencomm/CANopenCommand.c
+++ b/canopencomm/CANopenCommand.c
@@ -37,7 +37,7 @@
 
 
 #ifndef BUF_SIZE
-#define BUF_SIZE            100000
+#define BUF_SIZE            1000000
 #endif
 
 /* Helper functions */
@@ -217,7 +217,9 @@ int main (int argc, char *argv[]) {
     sa_family_t addrFamily = AF_UNIX;
     char  tcpPort[20] = "60000"; /* default port when used in tcp mode */
 
-    char buf[BUF_SIZE];
+    char* buf;
+    size_t bufSize = sizeof *buf * BUF_SIZE;
+    buf = malloc(bufSize);
     char hostname[HOST_NAME_MAX];
     int fd;
     struct sockaddr_un addr_un;
@@ -226,11 +228,13 @@ int main (int argc, char *argv[]) {
 
     if(argc >= 2 && strcmp(argv[1], "--help") == 0) {
         printUsage(argv[0]);
+        free(buf);
         exit(EXIT_SUCCESS);
     }
     if(argc >= 2 && strcmp(argv[1], "--helpall") == 0) {
         printUsage(argv[0]);
         printErrorDescs();
+        free(buf);
         exit(EXIT_SUCCESS);
     }
 
@@ -255,6 +259,7 @@ int main (int argc, char *argv[]) {
                 break;
             default:
                 printUsage(argv[0]);
+                free(buf);
                 exit(EXIT_FAILURE);
         }
     }
@@ -273,6 +278,7 @@ int main (int argc, char *argv[]) {
         errcode = getaddrinfo(hostname, tcpPort, &hints, &res);
         if (errcode != 0) {
             fprintf(stderr, "Error! Getaddrinfo for host %s failed\n", hostname);
+            free(buf);
             exit(EXIT_FAILURE);
         }
 
@@ -293,12 +299,14 @@ int main (int argc, char *argv[]) {
           }
 
           close(fd);
+          free(buf);
           errExit("Socket connection failed");
       }
     }
     else { // addrFamily == AF_UNIX
       fd = socket(AF_UNIX, SOCK_STREAM, 0);
       if(fd == -1) {
+          free(buf);
           errExit("Socket creation failed");
       }
 
@@ -307,6 +315,7 @@ int main (int argc, char *argv[]) {
       strncpy(addr_un.sun_path, socketPath, sizeof(addr_un.sun_path) - 1);
 
       if(connect(fd, (struct sockaddr *)&addr_un, sizeof(struct sockaddr_un)) == -1) {
+          free(buf);
           errExit("Socket connection failed");
       }
     }
@@ -316,6 +325,7 @@ int main (int argc, char *argv[]) {
     if(inputFilePath != NULL) {
         FILE *fp = fopen(inputFilePath, "r");
         if(fp == NULL) {
+            free(buf);
             errExit("Can't open input file");
         }
 
@@ -342,6 +352,7 @@ int main (int argc, char *argv[]) {
             buflen = strlen(buf);
             if(buflen >= (BUF_SIZE - 1)) {
                 fprintf(stderr, "String too long!\n");
+                free(buf);
                 exit(EXIT_FAILURE);
             }
         }
@@ -360,27 +371,33 @@ int main (int argc, char *argv[]) {
 
     close(fd);
 
+    free(buf);
     exit(EXIT_SUCCESS);
 }
 
 
 static void sendCommand(int fd, char* command, size_t commandLength) {
     size_t n;
-    char buf[BUF_SIZE];
 
+    char* replyBuf;
+    size_t bufSize = sizeof *replyBuf * BUF_SIZE;
+    replyBuf = malloc(bufSize);
+
+    // send command
     if (write(fd, command, commandLength) != commandLength) {
         errExit("Socket write failed");
     }
 
-    n = read(fd, buf, sizeof(buf));
+    //read reply
+    n = read(fd, replyBuf, bufSize);
 
     if(n == -1) {
         errExit("Socket read failed");
     }
 
     if(printErrorDescription == 1) {
-        char *errLoc = strstr(buf, "ERROR:");
-        char *endLoc = strstr(buf, "\r\n");
+        char *errLoc = strstr(replyBuf, "ERROR:");
+        char *endLoc = strstr(replyBuf, "\r\n");
 
         if(errLoc != NULL && endLoc != NULL) {
             int num;
@@ -405,6 +422,7 @@ static void sendCommand(int fd, char* command, size_t commandLength) {
         }
     }
 
-    printf("%s", buf);
+    printf("%s", replyBuf);
+    free(replyBuf);
 }
 

--- a/canopencomm/CANopenCommand.c
+++ b/canopencomm/CANopenCommand.c
@@ -320,6 +320,8 @@ int main (int argc, char *argv[]) {
       }
     }
 
+    printErrorDescription = 1; // always print error description
+
 
     /* get commands from input file, line after line */
     if(inputFilePath != NULL) {
@@ -358,7 +360,6 @@ int main (int argc, char *argv[]) {
         }
         buf[buflen - 1] = '\n'; /* replace last space with newline */
 
-        printErrorDescription = 1;
         sendCommand(fd, buf, buflen);
     }
 
@@ -396,10 +397,12 @@ static void sendCommand(int fd, char* command, size_t commandLength) {
     }
 
     if(printErrorDescription == 1) {
+        //check for error reply
         char *errLoc = strstr(replyBuf, "ERROR:");
         char *endLoc = strstr(replyBuf, "\r\n");
 
         if(errLoc != NULL && endLoc != NULL) {
+            //parse error code
             int num;
             char *sRet = NULL;
 
@@ -411,6 +414,7 @@ static void sendCommand(int fd, char* command, size_t commandLength) {
 
                 len = sizeof(errorDescs) / sizeof(errorDescs_t);
 
+                //lookup error code and print
                 for(i=0; i<len; i++) {
                     const errorDescs_t *ed = &errorDescs[i];
                     if(ed->code == num) {

--- a/canopend/src/CO_command.c
+++ b/canopend/src/CO_command.c
@@ -242,8 +242,8 @@ static void* command_thread(void* arg) {
 
         /* Read command and send answer. */
         while((n = read(fd, cmdBuf, cmdBufSize-1)) > 0) {
-            n++;
             *(cmdBuf + n) = 0; /* terminate input string */
+            n++;
             command_process(fd, cmdBuf, n);
         }
 
@@ -456,7 +456,7 @@ static void command_process(int fd, char* command, size_t commandLength) {
             }
 
             if(err == 0) {
-                dataTxLen = datatype->dataTypeScan((char*)dataTx, sizeof(dataTx), token);
+                dataTxLen = datatype->dataTypeScan((char*)dataTx, dataTxSize, token);
 
                 /* Length must match and must not be zero. */
                 if((datatype->length != 0 && datatype->length != dataTxLen) || dataTxLen == 0) {
@@ -968,13 +968,13 @@ static void command_process(int fd, char* command, size_t commandLength) {
 
 
     /* Terminate string and send response */
-    respLen++;
     *(resp + respLen) = '\r';
     respLen++;
     *(resp + respLen) = '\n';
+    respLen++;
     if(!tcpMode) {
-        respLen++;
         *(resp + respLen) = '\0';
+        respLen++;
     }
 
     if(write(fd, resp, respLen) != respLen) {

--- a/canopend/src/CO_command.c
+++ b/canopend/src/CO_command.c
@@ -44,7 +44,7 @@
 
 /* Maximum size of Object Dictionary variable transmitted via SDO. */
 #ifndef CO_COMMAND_SDO_BUFFER_SIZE
-#define CO_COMMAND_SDO_BUFFER_SIZE     100000
+#define CO_COMMAND_SDO_BUFFER_SIZE     1000000
 #endif
 
 #define STRING_BUFFER_SIZE  (CO_COMMAND_SDO_BUFFER_SIZE * 4 + 100)
@@ -227,7 +227,9 @@ int CO_command_clear_tcp(in_port_t port) {
 static void* command_thread(void* arg) {
     int fd;
     ssize_t n;
-    char buf[STRING_BUFFER_SIZE];
+    char* cmdBuf;
+    size_t cmdBufSize = sizeof *cmdBuf * STRING_BUFFER_SIZE;
+    cmdBuf = malloc(cmdBufSize);
 
     /* Almost endless loop */
     while(endProgram == 0) {
@@ -239,9 +241,10 @@ static void* command_thread(void* arg) {
         }
 
         /* Read command and send answer. */
-        while((n = read(fd, buf, sizeof(buf)-1)) > 0) {
-            buf[n++] = 0; /* terminate input string */
-            command_process(fd, buf, n);
+        while((n = read(fd, cmdBuf, cmdBufSize-1)) > 0) {
+            n++;
+            *(cmdBuf + n) = 0; /* terminate input string */
+            command_process(fd, cmdBuf, n);
         }
 
         if(n == -1){
@@ -254,6 +257,7 @@ static void* command_thread(void* arg) {
         }
     }
 
+    free(cmdBuf);
     return NULL;
 }
 
@@ -267,7 +271,9 @@ static void command_process(int fd, char* command, size_t commandLength) {
     uint32_t ui[3];
     uint8_t comm_node = 0xFF; /* undefined */
 
-    char resp[STRING_BUFFER_SIZE];
+    char* resp;
+    size_t respSize = sizeof *resp * STRING_BUFFER_SIZE;
+    resp = malloc(respSize);
     int respLen = 0;
     respErrorCode_t respErrorCode = respErrorNone;
 
@@ -353,7 +359,9 @@ static void command_process(int fd, char* command, size_t commandLength) {
             int errDt = 0;
             uint32_t SDOabortCode = 1;
 
-            uint8_t dataRx[CO_COMMAND_SDO_BUFFER_SIZE]; /* SDO receive buffer */
+            uint8_t* dataRx; /* SDO receive buffer */
+            size_t dataRxSize = sizeof *dataRx * CO_COMMAND_SDO_BUFFER_SIZE;
+            dataRx = malloc(dataRxSize);
             uint32_t dataRxLen;  /* Length of received data */
 
             token = getTok(NULL, spaceDelim, &err);
@@ -389,7 +397,7 @@ static void command_process(int fd, char* command, size_t commandLength) {
                         idx,
                         subidx,
                         dataRx,
-                        sizeof(dataRx),
+                        dataRxSize,
                         &dataRxLen,
                         &SDOabortCode,
                         SDOtimeoutTime,
@@ -406,17 +414,19 @@ static void command_process(int fd, char* command, size_t commandLength) {
                     respLen = sprintf(resp, "[%d] ", sequence);
 
                     if(datatype == NULL || (datatype->length != 0 && datatype->length != dataRxLen)) {
-                        respLen += dtpHex(resp+respLen, sizeof(resp)-respLen, (char*)dataRx, dataRxLen);
+                        respLen += dtpHex(resp+respLen, respSize-respLen, (char*)dataRx, dataRxLen);
                     }
                     else {
                         respLen += datatype->dataTypePrint(
-                                resp+respLen, sizeof(resp)-respLen, (char*)dataRx, dataRxLen);
+                                resp+respLen, respSize-respLen, (char*)dataRx, dataRxLen);
                     }
                 }
                 else{
                     respLen = sprintf(resp, "[%d] ERROR: 0x%08X", sequence, SDOabortCode);
                 }
             }
+
+            free(dataRx);
         }
 
         /* Download SDO command - w[rite] <index> <subindex> <datatype> <value> */
@@ -426,7 +436,9 @@ static void command_process(int fd, char* command, size_t commandLength) {
             const dataType_t *datatype;
             uint32_t SDOabortCode = 1;
 
-            uint8_t dataTx[CO_COMMAND_SDO_BUFFER_SIZE]; /* SDO transmit buffer */
+            uint8_t* dataTx; /* SDO transmit buffer */
+            size_t dataTxSize = sizeof *dataTx * CO_COMMAND_SDO_BUFFER_SIZE;
+            dataTx = malloc(dataTxSize);
             uint32_t dataTxLen = 0;  /* Length of data to transmit. */
 
             token = getTok(NULL, spaceDelim, &err);
@@ -490,6 +502,8 @@ static void command_process(int fd, char* command, size_t commandLength) {
                     respLen = sprintf(resp, "[%d] ERROR: 0x%08X", sequence, SDOabortCode);
                 }
             }
+
+            free(dataTx);
         }
 
         /* NMT start node */
@@ -758,16 +772,16 @@ static void command_process(int fd, char* command, size_t commandLength) {
                 if (err == 0) {
                     respLen = sprintf(resp, "[%d] ", sequence);
 
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&vendorId, sizeof(vendorId));
                     respLen += sprintf(resp+respLen, " ");
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&productCode, sizeof(productCode));
                     respLen += sprintf(resp+respLen, " ");
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&revisionNo, sizeof(revisionNo));
                     respLen += sprintf(resp+respLen, " ");
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&serialNo, sizeof(serialNo));
                 }
             }
@@ -817,16 +831,16 @@ static void command_process(int fd, char* command, size_t commandLength) {
                 if (err == 0) {
                     respLen = sprintf(resp, "[%d] ", sequence);
 
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&vendorId, sizeof(vendorId));
                     respLen += sprintf(resp+respLen, " ");
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&productCode, sizeof(productCode));
                     respLen += sprintf(resp+respLen, " ");
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&revisionNo, sizeof(revisionNo));
                     respLen += sprintf(resp+respLen, " ");
-                    respLen += datatype->dataTypePrint(resp+respLen, sizeof(resp)-respLen,
+                    respLen += datatype->dataTypePrint(resp+respLen, respSize-respLen,
                                    (char*)&serialNo, sizeof(serialNo));
                 }
             }
@@ -954,13 +968,18 @@ static void command_process(int fd, char* command, size_t commandLength) {
 
 
     /* Terminate string and send response */
-    resp[respLen++] = '\r';
-    resp[respLen++] = '\n';
+    respLen++;
+    *(resp + respLen) = '\r';
+    respLen++;
+    *(resp + respLen) = '\n';
     if(!tcpMode) {
-      resp[respLen++] = '\0';
+        respLen++;
+        *(resp + respLen) = '\0';
     }
 
     if(write(fd, resp, respLen) != respLen) {
         CO_error(0x15200000L);
     }
+
+    free(resp);
 }


### PR DESCRIPTION
One embedded systems with limited RAM increasing the size of canopend/canopencom buffers - which are allocated on the stack - crashes canopend. Changed that to heap allocation so that there is more headroom.
I've also enabled print of the error message description in all cases. Previously it was only enabled when using canopencomm via arguments. It's good to have control, i.e. enable/disable, but I don't see the point of changing the behavior depending on how a command is offered (via file, via argument, etc).
For those who are actively using in it scripts, if you want to parse the error code try using regex instead of looking for \r\n.